### PR TITLE
Add DataLoaderView snippets

### DIFF
--- a/src/ChinookSnippets/Chinook.DataLoader/DataLoader.pkgdef
+++ b/src/ChinookSnippets/Chinook.DataLoader/DataLoader.pkgdef
@@ -1,3 +1,7 @@
 ﻿// C#
 [$RootKey$\Languages\CodeExpansions\CSharp\Paths]
 "Chinook.DataLoader"="$PackageFolder$"
+
+// XAML
+[$RootKey$\Languages\CodeExpansions\XAML\Paths]
+"Chinook.DataLoader"="$PackageFolder$"

--- a/src/ChinookSnippets/Chinook.DataLoader/DataLoaderView.snippet
+++ b/src/ChinookSnippets/Chinook.DataLoader/DataLoaderView.snippet
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>DataLoaderView for x:Bind - C#</Title>
+      <Author>nventive</Author>
+      <Description>Code snippet to implement a class derivated from DataLoaderView and DataLoaderViewState where Data is typed. Use this in your page's code behind to generate a DataLoaderView compatible with x:Bind.</Description>
+      <HelpUrl></HelpUrl>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+      <Keywords>
+        <Keyword>Chinook DataLoaderView Code Snippet</Keyword>
+      </Keywords>
+      <Shortcut>ckdlv</Shortcut>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>Chinook.DataLoader.Uno</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>Chinook.DataLoader</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal Editable="true">
+          <ID>DataType</ID>
+          <Default>int</Default>
+        </Literal>        
+      </Declarations>
+      <Code Language="csharp" Kind="" Delimiter="$">
+        <![CDATA[public class DataLoaderViewState_$DataType$ : DataLoaderViewState
+	{
+		public DataLoaderViewState_$DataType$(DataLoaderViewState dataLoaderViewState) : base(dataLoaderViewState)
+		{
+			Data = ($DataType$)dataLoaderViewState.Data;
+		}
+
+		public new $DataType$ Data { get; }
+	}
+
+	public class DataLoaderView_$DataType$ : DataLoaderView
+	{
+		public DataLoaderView_$DataType$()
+		{
+			Style = App.Current.Resources[typeof(DataLoaderView)] as Style;
+		}
+
+		protected override void SetState(DataLoaderViewState state)
+		{
+			var typedState = new DataLoaderViewState_$DataType$(state);
+			base.SetState(typedState);
+		}
+	}]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/src/ChinookSnippets/Chinook.DataLoader/DataLoaderViewXAML.snippet
+++ b/src/ChinookSnippets/Chinook.DataLoader/DataLoaderViewXAML.snippet
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CodeSnippets xmlns="http://schemas.microsoft.com/VisualStudio/2005/CodeSnippet">
+  <CodeSnippet Format="1.0.0">
+    <Header>
+      <Title>DataLoaderView for x:Bind - XAML</Title>
+      <Author>nventive</Author>
+      <Description>Code snippet to add an x:Bind compatible DataLoaderView. You should use ckdlv in your C# code behind beforehand.</Description>
+      <HelpUrl></HelpUrl>
+      <SnippetTypes>
+        <SnippetType>Expansion</SnippetType>
+      </SnippetTypes>
+      <Keywords>
+        <Keyword>Chinook DataLoaderView Code Snippet</Keyword>
+      </Keywords>
+      <Shortcut>ckdlvx</Shortcut>
+    </Header>
+    <Snippet>
+      <References>
+        <Reference>
+          <Assembly>Chinook.DataLoader.Uno</Assembly>
+        </Reference>
+      </References>
+      <Imports>
+        <Import>
+          <Namespace>Chinook.DataLoader</Namespace>
+        </Import>
+      </Imports>
+      <Declarations>
+        <Literal Editable="true">
+          <ID>DataType</ID>
+          <Default>int</Default>
+        </Literal>
+        <Literal Editable="true">
+          <ID>Source</ID>
+          <Default>DataLoader</Default>
+        </Literal>
+      </Declarations>
+      <Code Language="XAML" Kind="" Delimiter="$">
+        <![CDATA[<local:DataLoaderView_$DataType$ Source="{x:Bind $Source$}">
+  <DataTemplate x:DataType="local:DataLoaderViewState_$DataType$">
+  </DataTemplate>
+</local:DataLoaderView_$DataType$>]]>
+      </Code>
+    </Snippet>
+  </CodeSnippet>
+</CodeSnippets>

--- a/src/ChinookSnippets/ChinookSnippets.csproj
+++ b/src/ChinookSnippets/ChinookSnippets.csproj
@@ -139,6 +139,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <Content Include="Chinook.DataLoader\DataLoaderViewXAML.snippet">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Chinook.DataLoader\DataLoaderView.snippet">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Feature 

## Description
- Added snippets to be able to use `x:Bind` inside a `DataLoaderView`.
  - `ckdlv` (**C**hinoo**k** **D**ata**L**oader**V**iew) is used to generate a strongly type `DataLoaderView` and `DataLoaderViewState` in C# code behind.
  - `ckdlvx` (**C**hinoo**k** **D**ata**L**oader**V**iew **X**AML) is used to instantiate the previously generated custom `DataLoaderView` in xaml and specifiy the `DataLoaderViewState` (the DataContext) type.

## Checklist

Please check if your PR fulfills the following requirements:

- [x] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [ ] Associated with an issue

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->


## Other information
<!-- Please provide any additional information if necessary -->

